### PR TITLE
Add a status conection message

### DIFF
--- a/wgnord
+++ b/wgnord
@@ -82,6 +82,16 @@ is_connected() {
 	ip link show wgnord > /dev/null 2>&1
 	return
 }
+
+status() {
+	if is_connected; then
+		server_ip="$(wg show wgnord endpoints | awk '{print $2}')"
+		print "Connected to: $server_ip"
+	else
+		print_error "No active VPN connection"
+	fi
+}
+
 help() { cat << EOF
 Usage: wgnord [ l(ogin) | c(onnect) | d(isconnect) | a(ccount) ]
 
@@ -98,6 +108,9 @@ disconnect:
 account:
     wgnord a
     Prints information about the currently logged in account
+status:
+    wgnord s
+    Prints current VPN connection status
 
 wgnord's files are in $conf_dir, edit template.conf to change Wireguard options
 EOF
@@ -109,5 +122,6 @@ case $1 in
 	c|connect) check_root; shift; connect "$@" ;;
 	d|disconnect) check_root; disconnect ;;
 	a|account) check_root; account ;;
+	s|status) check_root; status ;;
 	*) help ;;
 esac


### PR DESCRIPTION
I have added some lines to print the active connection, 
I have not tested this a lot, but i think its fine.
If this is added i may also make sense
to update the User-Agent to keep it working for longer.
I'm not sure if nordvpn allows old clients forever.
So the current usersting would be someting like (not shure if also to set a newer kernel):
'User-Agent: NordApp Linux 3.18.4 Linux 5.4.0-58-generic'
If any kernel should be used then 6.8.0-41-generic
This is the ubuntu 2404 LTS kernel, then it would be:
'User-Agent: NordApp Linux 3.18.4 Linux 6.8.0-41-generic'
I cloud also be set to the latest LTS kernel 6.6.32-1.