### PR TITLE
Add support for specific servers

### DIFF
--- a/wgnord
+++ b/wgnord
@@ -61,20 +61,18 @@ connect() {
 		latitude="$(jq -er '.latitude' $conf_dir/coords.json)"
 	fi
 
-	servernr=$(echo "$1" | sed 's/[^0-9]//g') # get server number
-	[[ -z $servernr ]] && limit=10 || limit=99999 # If server nr is reqested get all servers for that country otherwise get 10 best servers
+	servernr=$(echo "$1" | sed 's/[^0-9]//g')
+	limit=10
+	[ -n "$servernr" ] && limit=99999
 
 	country_code="$(get_country_code "$1")"
 	recommendations="$(query "https://$host/v1/servers/recommendations?limit=$limit&filters%5Bservers.status%5D=online&filters%5Bservers_technologies%5D=35&filters%5Bservers_technologies%5D%5Bpivot%5D%5Bstatus%5D=online&fields%5Bservers.id%5D&fields%5Bservers.name%5D&fields%5Bservers.hostname%5D&fields%5Bservers.station%5D&fields%5Bservers.status%5D&fields%5Bservers.load%5D&fields%5Bservers.created_at%5D&fields%5Bservers.groups.id%5D&fields%5Bservers.groups.title%5D&fields%5Bservers.technologies.id%5D&fields%5Bservers.technologies.metadata%5D&fields%5Bservers.technologies.pivot.status%5D&fields%5Bservers.specifications.identifier%5D&fields%5Bservers.specifications.values.value%5D&fields%5Bservers.locations.country.name%5D&fields%5Bservers.locations.country.code%5D&fields%5Bservers.locations.country.city.name%5D&fields%5Bservers.locations.country.city.latitude%5D&fields%5Bservers.locations.country.city.longitude%5D&coordinates%5Blongitude%5D=$longitude&coordinates%5Blatitude%5D=$latitude&fields%5Bservers.ips%5D&filters%5Bcountry_id%5D=$country_code")"
 
-	# If a server number is requested use it
-	[[ ! -z $servernr ]] && index=$(echo "$recommendations" | jq --arg sr "$servernr" 'to_entries[] | select(.value.hostname | test("[a-zA-Z]*\($sr)\\.")) | .key')
+	[ -n "$servernr" ] && index=$(echo "$recommendations" | jq --arg sr "$servernr" 'to_entries[] | select(.value.hostname | test("[a-zA-Z]*\($sr)\\.")) | .key')
 
-	if [[ -z $index ]] # If no server is set
-	then
-		# But if the server number was set then the sever was not found
-		[[ ! -z $servernr ]] && echo "Could not find server $country_code$servernr using best server"
-		index=0 # Set the index to the best server
+	if [ -z "$index" ]; then
+    		[ -n "$servernr" ] && echo "Could not find server $country_code$servernr, using best server"
+    		index=0
 	fi
 
 	server_name=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .name')

--- a/wgnord
+++ b/wgnord
@@ -26,8 +26,9 @@ login() {
 	echo -n $auth_token > $conf_dir/auth_token
 }
 get_country_code() {
-	buf="$(grep -i "^$1	" -m 1 $conf_dir/countries_iso31662.txt | cut -d "	" -f 2)"
-	[ -z "$buf" ] && buf="$(grep -i "$1" -m 1 $conf_dir/countries.txt | cut -d "	" -f 2)"
+	cleancode=$(echo "$1" | sed 's/[0-9]*//g')
+	buf="$(grep -i -E "^$cleancode" -m 1 $conf_dir/countries_iso31662.txt | cut -d "	" -f 2)"
+	[ -z "$buf" ] && buf="$(grep -i "$cleancode" -m 1 $conf_dir/countries.txt | cut -d "	" -f 2)"
 	echo "$buf"
 }
 connect() {
@@ -56,12 +57,50 @@ connect() {
 		longitude="$(jq -er '.longitude' $conf_dir/coords.json)"
 		latitude="$(jq -er '.latitude' $conf_dir/coords.json)"
 	fi
-	country_code="$(get_country_code "$1")"
-	recommendations="$(query "https://$host/v1/servers/recommendations?limit=20&filters%5Bservers.status%5D=online&filters%5Bservers_technologies%5D=35&filters%5Bservers_technologies%5D%5Bpivot%5D%5Bstatus%5D=online&fields%5Bservers.id%5D&fields%5Bservers.name%5D&fields%5Bservers.hostname%5D&fields%5Bservers.station%5D&fields%5Bservers.status%5D&fields%5Bservers.load%5D&fields%5Bservers.created_at%5D&fields%5Bservers.groups.id%5D&fields%5Bservers.groups.title%5D&fields%5Bservers.technologies.id%5D&fields%5Bservers.technologies.metadata%5D&fields%5Bservers.technologies.pivot.status%5D&fields%5Bservers.specifications.identifier%5D&fields%5Bservers.specifications.values.value%5D&fields%5Bservers.locations.country.name%5D&fields%5Bservers.locations.country.code%5D&fields%5Bservers.locations.country.city.name%5D&fields%5Bservers.locations.country.city.latitude%5D&fields%5Bservers.locations.country.city.longitude%5D&coordinates%5Blongitude%5D=$longitude&coordinates%5Blatitude%5D=$latitude&fields%5Bservers.ips%5D&filters%5Bcountry_id%5D=$country_code")"
-	server_name="$(echo "$recommendations" | jq -j '.[0] | .name')"
-	server_hostname="$(echo "$recommendations" | jq -j '.[0] | .hostname')"
-	server_ip="$(echo "$recommendations" | jq -j '.[0] | .ips[0].ip.ip')"
-	server_pubkey="$(echo "$recommendations" | jq -j '.[0] | .technologies[] | select(.metadata[0].name == "public_key") | .metadata[0].value')"
+		servernr=$(echo "$1" | sed 's/[^0-9]//g')
+	limit=10
+	if [[ ! -z $servernr ]] # If a sever nr was requested increase the limit to search more servers
+	then
+		limit=$((limit*10))
+	fi
+	awnsernrs=$limit
+
+	while [[ -z $index ]]  # while we dont know what server to use we get servers
+	do
+		recommendations="$(query "https://$host/v1/servers/recommendations?limit=$limit&filters%5Bservers.status%5D=online&filters%5Bservers_technologies%5D=35&filters%5Bservers_technologies%5D%5Bpivot%5D%5Bstatus%5D=online&fields%5Bservers.id%5D&fields%5Bservers.name%5D&fields%5Bservers.hostname%5D&fields%5Bservers.station%5D&fields%5Bservers.status%5D&fields%5Bservers.load%5D&fields%5Bservers.created_at%5D&fields%5Bservers.groups.id%5D&fields%5Bservers.groups.title%5D&fields%5Bservers.technologies.id%5D&fields%5Bservers.technologies.metadata%5D&fields%5Bservers.technologies.pivot.status%5D&fields%5Bservers.specifications.identifier%5D&fields%5Bservers.specifications.values.value%5D&fields%5Bservers.locations.country.name%5D&fields%5Bservers.locations.country.code%5D&fields%5Bservers.locations.country.city.name%5D&fields%5Bservers.locations.country.city.latitude%5D&fields%5Bservers.locations.country.city.longitude%5D&coordinates%5Blongitude%5D=$longitude&coordinates%5Blatitude%5D=$latitude&fields%5Bservers.ips%5D&filters%5Bcountry_id%5D=$country_code")"
+		awnsernrs=$(echo "$recommendations" | jq 'length')
+
+		if [[ ! -z $servernr ]] # If the user has set a server number to use
+		then
+			# Set the matching sever
+			index=""
+			index=$(echo "$recommendations" | jq --arg sr "$servernr" 'to_entries[] | select(.value.hostname | test("[a-zA-Z]*\($sr)\\.")) | .key')
+		else # If the user only set the country break
+			break
+		fi
+		if [ ! -z "$index" ] # if the requested sever was found break
+		then
+			break
+		fi
+		if [[ $awnsernrs -lt $limit ]] # if there are less servers then the limit,
+		then # then no more servers exist so we can break
+			break
+		fi
+		limit=$((limit*10))
+	done
+	if [[ -z $index ]] # If no server is set
+	then
+		if [[ ! -z $servernr ]] # But if server nr is set
+		then # then no matching server was found
+			echo "Could not find server $country_code$servernr using best server"
+		fi
+		# Set the index to the best server
+		index=0
+	fi
+	server_name=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .name')
+	server_hostname=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .hostname')
+	server_ip=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .ips[0].ip.ip')
+	server_pubkey=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .technologies[] | select(.metadata[0].name == "public_key") | .metadata[0].value')
 	privkey="$(jq -j '.nordlynx_private_key' $conf_dir/credentials.json)"
 	sed -e "s|PRIVKEY|$privkey|" -e "s|SERVER_PUBKEY|$server_pubkey|" -e "s|SERVER_IP|$server_ip|" $conf_dir/template.conf > "$out_file"
 	if [ ! $dont_act ]; then

--- a/wgnord
+++ b/wgnord
@@ -60,50 +60,28 @@ connect() {
 		longitude="$(jq -er '.longitude' $conf_dir/coords.json)"
 		latitude="$(jq -er '.latitude' $conf_dir/coords.json)"
 	fi
-		servernr=$(echo "$1" | sed 's/[^0-9]//g')
-	limit=10
-	if [[ ! -z $servernr ]] # If a sever nr was requested increase the limit to search more servers
-	then
-		limit=$((limit*10))
-	fi
-	awnsernrs=$limit
 
-	while [[ -z $index ]]  # while we dont know what server to use we get servers
-	do
-		recommendations="$(query "https://$host/v1/servers/recommendations?limit=$limit&filters%5Bservers.status%5D=online&filters%5Bservers_technologies%5D=35&filters%5Bservers_technologies%5D%5Bpivot%5D%5Bstatus%5D=online&fields%5Bservers.id%5D&fields%5Bservers.name%5D&fields%5Bservers.hostname%5D&fields%5Bservers.station%5D&fields%5Bservers.status%5D&fields%5Bservers.load%5D&fields%5Bservers.created_at%5D&fields%5Bservers.groups.id%5D&fields%5Bservers.groups.title%5D&fields%5Bservers.technologies.id%5D&fields%5Bservers.technologies.metadata%5D&fields%5Bservers.technologies.pivot.status%5D&fields%5Bservers.specifications.identifier%5D&fields%5Bservers.specifications.values.value%5D&fields%5Bservers.locations.country.name%5D&fields%5Bservers.locations.country.code%5D&fields%5Bservers.locations.country.city.name%5D&fields%5Bservers.locations.country.city.latitude%5D&fields%5Bservers.locations.country.city.longitude%5D&coordinates%5Blongitude%5D=$longitude&coordinates%5Blatitude%5D=$latitude&fields%5Bservers.ips%5D&filters%5Bcountry_id%5D=$country_code")"
-		awnsernrs=$(echo "$recommendations" | jq 'length')
+	servernr=$(echo "$1" | sed 's/[^0-9]//g') # get server number
+	[[ -z $servernr ]] && limit=10 || limit=99999 # If server nr is reqested get all servers for that country otherwise get 10 best servers
 
-		if [[ ! -z $servernr ]] # If the user has set a server number to use
-		then
-			# Set the matching sever
-			index=""
-			index=$(echo "$recommendations" | jq --arg sr "$servernr" 'to_entries[] | select(.value.hostname | test("[a-zA-Z]*\($sr)\\.")) | .key')
-		else # If the user only set the country break
-			break
-		fi
-		if [ ! -z "$index" ] # if the requested sever was found break
-		then
-			break
-		fi
-		if [[ $awnsernrs -lt $limit ]] # if there are less servers then the limit,
-		then # then no more servers exist so we can break
-			break
-		fi
-		limit=$((limit*10))
-	done
+	country_code="$(get_country_code "$1")"
+	recommendations="$(query "https://$host/v1/servers/recommendations?limit=$limit&filters%5Bservers.status%5D=online&filters%5Bservers_technologies%5D=35&filters%5Bservers_technologies%5D%5Bpivot%5D%5Bstatus%5D=online&fields%5Bservers.id%5D&fields%5Bservers.name%5D&fields%5Bservers.hostname%5D&fields%5Bservers.station%5D&fields%5Bservers.status%5D&fields%5Bservers.load%5D&fields%5Bservers.created_at%5D&fields%5Bservers.groups.id%5D&fields%5Bservers.groups.title%5D&fields%5Bservers.technologies.id%5D&fields%5Bservers.technologies.metadata%5D&fields%5Bservers.technologies.pivot.status%5D&fields%5Bservers.specifications.identifier%5D&fields%5Bservers.specifications.values.value%5D&fields%5Bservers.locations.country.name%5D&fields%5Bservers.locations.country.code%5D&fields%5Bservers.locations.country.city.name%5D&fields%5Bservers.locations.country.city.latitude%5D&fields%5Bservers.locations.country.city.longitude%5D&coordinates%5Blongitude%5D=$longitude&coordinates%5Blatitude%5D=$latitude&fields%5Bservers.ips%5D&filters%5Bcountry_id%5D=$country_code")"
+
+	# If a server number is requested use it
+	[[ ! -z $servernr ]] && index=$(echo "$recommendations" | jq --arg sr "$servernr" 'to_entries[] | select(.value.hostname | test("[a-zA-Z]*\($sr)\\.")) | .key')
+
 	if [[ -z $index ]] # If no server is set
 	then
-		if [[ ! -z $servernr ]] # But if server nr is set
-		then # then no matching server was found
-			echo "Could not find server $country_code$servernr using best server"
-		fi
-		# Set the index to the best server
-		index=0
+		# But if the server number was set then the sever was not found
+		[[ ! -z $servernr ]] && echo "Could not find server $country_code$servernr using best server"
+		index=0 # Set the index to the best server
 	fi
+
 	server_name=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .name')
 	server_hostname=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .hostname')
 	server_ip=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .ips[0].ip.ip')
 	server_pubkey=$(echo "$recommendations" | jq -j --argjson idx "$index" '.[$idx] | .technologies[] | select(.metadata[0].name == "public_key") | .metadata[0].value')
+
 	privkey="$(jq -j '.nordlynx_private_key' $conf_dir/credentials.json)"
 	sed -e "s|PRIVKEY|$privkey|" -e "s|SERVER_PUBKEY|$server_pubkey|" -e "s|SERVER_IP|$server_ip|" $conf_dir/template.conf > "$out_file"
 	if [ ! $dont_act ]; then


### PR DESCRIPTION
Add support for specific servers as requested by:
https://github.com/phirecc/wgnord/issues/5

I'm doing this by taking the letters / number from "wgnord c"
and if numbers are at the end of "wgnord c" like for "wgnord c  de333"
in get_contry_code we remove the number 
and in the sever selection we use only the number.
Then we check if that number exists in the hostnames.
If not we try once more whit a higher limit.
from there if can stop
- if there are less results than limits (no more servers to use)
- the index was found
- or if there was no number in the first place it will stop on the first try
Then if there is no index we select 0 (best server).
The rest basically works the same.

Be happy for any and all ideas, to make this  better