### PR TITLE
chmod wireguard wgnord.conf to suppress wg-quick warning

### DIFF
--- a/wgnord
+++ b/wgnord
@@ -82,6 +82,7 @@ connect() {
 
 	privkey="$(jq -j '.nordlynx_private_key' $conf_dir/credentials.json)"
 	sed -e "s|PRIVKEY|$privkey|" -e "s|SERVER_PUBKEY|$server_pubkey|" -e "s|SERVER_IP|$server_ip|" $conf_dir/template.conf > "$out_file"
+	chmod 600 "$out_file"
 	if [ ! $dont_act ]; then
 		print "Connecting to $server_hostname ($server_name)..."
 		if is_connected; then


### PR DESCRIPTION
chmod wgnord.conf to only user rw to suppress wg-quick warning. On nixos, currently wg-quick gives:
Warning: '/etc/wireguard/wgnord.conf' is world accessible.