### PR TITLE
chmod wireguard wgnord.conf to suppress wg-quick warning

### DIFF
--- a/wgnord
+++ b/wgnord
@@ -82,6 +82,7 @@ connect() {
 
 	privkey="$(jq -j '.nordlynx_private_key' $conf_dir/credentials.json)"
 	sed -e "s|PRIVKEY|$privkey|" -e "s|SERVER_PUBKEY|$server_pubkey|" -e "s|SERVER_IP|$server_ip|" $conf_dir/template.conf > "$out_file"
+	chmod 600 "$out_file"
 	if [ ! $dont_act ]; then
 		print "Connecting to $server_hostname ($server_name)..."
 		if is_connected; then


### PR DESCRIPTION
Hi @phirecc 

On nixos using home-manager, I installed the wgnord package and it works well.

However when running the script, wg-quick outputs the warning:
"Warning: '/etc/wireguard/wgnord.conf' is world accessible"

To replicate the issue locally, remove /etc/wireguard/wgnord.conf before running wgnord.

So here's a PR which chmods the file to just user rw to suppress the wg-quick warning.

Thanks,
Jon